### PR TITLE
[LLDP] Fix lldpshow script to enable display multiple MAC addresses on the same remote physical interface

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -128,28 +128,33 @@ class Lldpshow(object):
                 l_intf = intf.attrib['name']
                 if l_intf.startswith(BACKEND_ASIC_INTERFACE_NAME_PREFIX):
                     continue
-                self.lldpsum[l_intf] = {}
+                remote_port = intf.find('port')
+                r_portid = remote_port.find('id').text
+                key = l_intf + "#" + r_portid
+                self.lldpsum[key] = {}
+                self.lldpsum[key]['l_intf'] = l_intf
+                self.lldpsum[key]['r_portid'] = r_portid
                 chassis = intf.find('chassis')
                 capabs = chassis.findall('capability')
                 capab = self.parse_cap(capabs)
                 rmt_name = chassis.find('name')
                 if rmt_name is not None:
-                    self.lldpsum[l_intf]['r_name'] = rmt_name.text
+                    self.lldpsum[key]['r_name'] = rmt_name.text
                 else:
-                    self.lldpsum[l_intf]['r_name'] = ''
-                remote_port = intf.find('port')
-                self.lldpsum[l_intf]['r_portid'] = remote_port.find('id').text
+                    self.lldpsum[key]['r_name'] = ''
                 rmt_desc = remote_port.find('descr')
                 if rmt_desc is not None:
-                    self.lldpsum[l_intf]['r_portname'] = rmt_desc.text
+                    self.lldpsum[key]['r_portname'] = rmt_desc.text
                 else:
-                    self.lldpsum[l_intf]['r_portname'] = ''
-                self.lldpsum[l_intf]['capability'] = capab
+                    self.lldpsum[key]['r_portname'] = ''
+                self.lldpsum[key]['capability'] = capab
 
     def sort_sum(self, summary):
-        """ Sort the summary information in the way that is expected(natural string)."""
-        def alphanum_key(key): return [re.findall('[A-Za-z]+', key) + [int(port_num)
-                                                                       for port_num in re.findall('\d+', key)]]
+        """ Sort the summary information in the way that is expected(natural string)."""                                                       
+        def alphanum_key(key): 
+            key = key.split("#")[0]
+            return [re.findall('[A-Za-z]+', key) + [int(port_num)
+                                                    for port_num in re.findall('\d+', key)]]
         return sorted(summary, key=alphanum_key)
 
     def display_sum(self, lldp_detail_info):
@@ -168,7 +173,7 @@ class Lldpshow(object):
             header = ['LocalPort', 'RemoteDevice', 'RemotePortID', 'Capability', 'RemotePortDescr']
             sortedsum = self.sort_sum(self.lldpsum)
             for key in sortedsum:
-                lldpstatus.append([key, self.lldpsum[key]['r_name'], self.lldpsum[key]['r_portid'],
+                lldpstatus.append([self.lldpsum[key]['l_intf'], self.lldpsum[key]['r_name'], self.lldpsum[key]['r_portid'],
                                    self.lldpsum[key]['capability'], self.lldpsum[key]['r_portname']])
             print(tabulate(lldpstatus, header))
             print('-'.rjust(50, '-'))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix lldpshow script to enable display multiple MAC addresses on the same remote physical interface

#### How I did it
Root cause:
"show lldp table" command uses lldpshow script to get, parse and display data from the lldp open source packge (lldpctl script).
lldpctl script returns a proper info about the 2 MACs but the issue is with the lldpshow script parser where it built a dictionary which its key is the local physical interface.
Therefore when having 2 MACs, lldpctl will return 2 entries but the lldpshow parser will overwrite the first enrty.

Fix:
Change the key to be a string of "interface#MAC".
This will enable having 2 entries for 2 differnent MAC addresses.

#### How to verify it
Scenario:
1- remote interface has 2 MACs on the same physical interface.
2- "show lldp table" command displays 2 entries for the 2 MAC addresses.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

